### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+
+# The order matters with a later match taking precedence,
+# Default Code Owners will be your maintainer team. 
+# Set a 
+# review when someone opens a pull request.
+*       @jpmorganchase/demo-wholesale-payments_maintainer


### PR DESCRIPTION
Recommended Control Addition
Via your Repository we can set a Branch protection rule via Settings > Branches > Add rule
Branch name pattern : main  [or pattern of choice] 
Select Require pull request reviews before merging > Require review from Code Owners
Click Create
Note the rules will show which branches that rule will be enabled on.

Suggest we create this CODEOWNERS in the .github/ directory of the repository.
People with admin or owner permissions can set up a CODEOWNERS file in a repository
Example of a CODEOWNERS file
# Each line is a file pattern followed by one or more owners.

# The order matters with a later match taking precedence,
# Default Code Owners will be your maintainer team. 
# Set a 
# review when someone opens a pull request.
*       @jpmorganchase/demo-wholesale-payments_maintainer

